### PR TITLE
Remove php 5.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
     - 5.6
     - 5.5
     - 5.4
-    - 5.3
 
 matrix:
     allow_failures:


### PR DESCRIPTION
PHP 5.3 officially dies 14 Aug 2014 (http://php.net/releases/) and it brings some nasty array issues ([] syntax not supported). This is why it should be removed from travis. An dead/unsupported php version that makes trouble! :)
