### PR TITLE
Add same tests to travis and local env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,4 @@ before_script:
     - composer update --dev --no-interaction
 
 script:
-    - output=$(php -n php-cs-fixer.phar fix -v --dry-run --level=all src); if [[ $output ]]; then while read -r line; do echo -e "\e[00;31m$line\e[00m"; done <<< "$output"; false; fi;
-    - "./vendor/bin/phpunit"
+    - composer test

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.1.0",
-        "squizlabs/php_codesniffer": "*"
+        "squizlabs/php_codesniffer": "*",
+        "fabpot/php-cs-fixer": "^1.11"
     },
     "scripts": {
-        "test": "vendor/bin/phpcs --standard=PSR2 src/Bookworm/Bookworm.php && phpunit"
+        "test": "echo '\\033[1;33m\nRunning: php codesniffer...\\033[0m'; vendor/bin/phpcs --standard=PSR2 src/Bookworm/Bookworm.php && echo '\\033[1;33mRunning: phpunit...\\033[0m'; phpunit && vendor/bin/php-cs-fixer fix --diff -v --dry-run src"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
We need to get an overall standard, it is a nightmare to have travis tests I can not replicate locally, because this means I have to send a PR to find problems with the coding style. Also I added the diff view to php-cs-fixer, which makes it a little less horrible.

Honestly, I would suggest to just toss php-cs-fixer and rely on php-cs, which has a decent report, the fixer is just not really meant to report the issues.
